### PR TITLE
Fixed issue where iskalliumGenerationPatchSize was not used

### DIFF
--- a/src/main/java/zairus/iskalliumreactors/world/gen/feature/WorldGenIskalliumOre.java
+++ b/src/main/java/zairus/iskalliumreactors/world/gen/feature/WorldGenIskalliumOre.java
@@ -1,7 +1,5 @@
 package zairus.iskalliumreactors.world.gen.feature;
 
-import java.util.Random;
-
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.DimensionType;
 import net.minecraft.world.World;
@@ -11,28 +9,48 @@ import net.minecraftforge.fml.common.IWorldGenerator;
 import zairus.iskalliumreactors.IRConfig;
 import zairus.iskalliumreactors.block.IRBlocks;
 
+import java.util.Random;
+
 public class WorldGenIskalliumOre implements IWorldGenerator
 {
+	private final WorldGenIRMineable worldGenIRMineable;
+
+	public WorldGenIskalliumOre() {
+		worldGenIRMineable = new WorldGenIRMineable(IRBlocks.ISKALLIUM_STONE_ORE.getDefaultState());
+	}
+
 	@Override
 	public void generate(Random rand, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider)
 	{
-		if (rand.nextInt(3) == 0 && world.provider.getDimensionType() == DimensionType.OVERWORLD)
-		{
+		if (world.provider.getDimensionType() != DimensionType.OVERWORLD) {
+			return;
+		}
+
+		int check = rand.nextInt(9);
+		if (check == 0) {
 			int x = (chunkX * 16) + rand.nextInt(16);
 			int y = 2 + rand.nextInt(15);
 			int z = (chunkZ * 16) + rand.nextInt(16);
-			
-			BlockPos pos = new BlockPos(x, y, z);
-			
+
 			int size = 1 + rand.nextInt(IRConfig.iskalliumGenerationPatchSize);
-			int check = rand.nextInt(3);
-			
 			if (size < 1)
 				size = 1;
-			
-			if (check == 0)
-			{
-				(new WorldGenIRMineable(IRBlocks.ISKALLIUM_STONE_ORE.getDefaultState())).generate(world, rand, pos);
+
+			for (int i = 0; i < size; i ++) {
+				worldGenIRMineable.generate(world, rand, new BlockPos(x, y, z));
+
+				// random walk in one axis at a time
+				switch (rand.nextInt(3)) {
+					case 0:
+						x += rand.nextInt(2) - 1;
+						break;
+					case 1:
+						y += rand.nextInt(2) - 1;
+						break;
+					case 2:
+						z += rand.nextInt(2) - 1;
+						break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hello Zairus,

I noticed that iskalliumGenerationPatchSize wasn't used in the code. I've never modded minecraft before and I didn't find any simple small ore vein generation online. I went with MVP (random-walk) approach here. It doesn't create clusters (like diamond veins) but rather lines-like formations.

Thanks,
Wayne

P.S.: I didn't find any license related to this code. How would you like me to proceed?