### PR TITLE
Fixed issue where quantum quarry and deep dark doesn't generate iskallium ore

### DIFF
--- a/src/main/java/zairus/iskalliumreactors/world/gen/feature/WorldGenIRMineable.java
+++ b/src/main/java/zairus/iskalliumreactors/world/gen/feature/WorldGenIRMineable.java
@@ -1,38 +1,41 @@
 package zairus.iskalliumreactors.world.gen.feature;
 
-import java.util.Random;
-
 import com.google.common.base.Predicate;
-
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.block.state.pattern.BlockMatcher;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenMinable;
 import net.minecraft.world.gen.feature.WorldGenerator;
+import zairus.iskalliumreactors.IRConfig;
+
+import java.util.Random;
 
 public class WorldGenIRMineable extends WorldGenerator
 {
 	private final IBlockState oreBlock;
 	private final Predicate<IBlockState> predicate;
-	
+	private final WorldGenMinable worldGenMinable;
+
 	public WorldGenIRMineable(IBlockState state)
 	{
 		this.oreBlock = state;
 		this.predicate = BlockMatcher.forBlock(Blocks.STONE);
+		this.worldGenMinable = new WorldGenMinable(state, IRConfig.iskalliumGenerationPatchSize);
 	}
 	
 	@Override
 	public boolean generate(World world, Random rand, BlockPos pos)
 	{
-		boolean generated = false;
+		// Ensure at least 1 ore is generated
 		IBlockState state = world.getBlockState(pos);
-		
 		if (state.getBlock().isReplaceableOreGen(state, world, pos, this.predicate))
 		{
-			generated = world.setBlockState(pos, this.oreBlock, 2);
+			world.setBlockState(pos, this.oreBlock, 2);
 		}
-		
-		return generated;
+
+		// Generate rest of the vein
+		return worldGenMinable.generate(world, rand, pos);
 	}
 }

--- a/src/main/java/zairus/iskalliumreactors/world/gen/feature/WorldGenIskalliumOre.java
+++ b/src/main/java/zairus/iskalliumreactors/world/gen/feature/WorldGenIskalliumOre.java
@@ -1,12 +1,10 @@
 package zairus.iskalliumreactors.world.gen.feature;
 
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.DimensionType;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkGenerator;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraftforge.fml.common.IWorldGenerator;
-import zairus.iskalliumreactors.IRConfig;
 import zairus.iskalliumreactors.block.IRBlocks;
 
 import java.util.Random;
@@ -22,36 +20,14 @@ public class WorldGenIskalliumOre implements IWorldGenerator
 	@Override
 	public void generate(Random rand, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider)
 	{
-		if (world.provider.getDimensionType() != DimensionType.OVERWORLD) {
-			return;
-		}
-
 		int check = rand.nextInt(9);
-		if (check == 0) {
+		if (check == 0)
+		{
 			int x = (chunkX * 16) + rand.nextInt(16);
 			int y = 2 + rand.nextInt(15);
 			int z = (chunkZ * 16) + rand.nextInt(16);
 
-			int size = 1 + rand.nextInt(IRConfig.iskalliumGenerationPatchSize);
-			if (size < 1)
-				size = 1;
-
-			for (int i = 0; i < size; i ++) {
-				worldGenIRMineable.generate(world, rand, new BlockPos(x, y, z));
-
-				// random walk in one axis at a time
-				switch (rand.nextInt(3)) {
-					case 0:
-						x += rand.nextInt(2) - 1;
-						break;
-					case 1:
-						y += rand.nextInt(2) - 1;
-						break;
-					case 2:
-						z += rand.nextInt(2) - 1;
-						break;
-				}
-			}
+			worldGenIRMineable.generate(world, rand, new BlockPos(x, y, z));
 		}
 	}
 }


### PR DESCRIPTION
Hello WinterGrave,

Thanks for accepting the previous pull request. :)

This pull request has two changes:

1) I've figured how to generate veins using the WorldGenMinable (instead of my MVP using random-walk,) sadly, it doesn't consistently generate 1 size all the time. I figured this is better than previous pull request.

2) I've removed the overworld dimension restriction in the world generator. We already use a 'stone' predicate for generating the ore, so any realm with stone at the bottom of the map should now generate iskallium ore.

I've tested this with both the deep dark and the quantum quarry.

Thanks again!
